### PR TITLE
Remote attach

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -331,7 +331,7 @@ function resolve(options, callback) {
             if (uri.protocol) {
                 var filepath = path.join(cache, cachepath(l.Datasource.file));
                 localize(uri.href, filepath, function(err, file) {
-                    if (err) next(err);
+                    if (err) return next(err);
                     symlink(file, next)
                 });
             // Absolute path.
@@ -377,8 +377,8 @@ function resolve(options, callback) {
                         // URL.
                         if (file.protocol) {
                             var filepath = path.join(cache, cachepath(file.href));
-                            // todo what here breaks
-                            localize(file.href, filepath, function() {
+                            localize(file.href, filepath, function(err) {
+                                if (err) return next(err);
                                 symlink(filepath, next);
                             });
                         }


### PR DESCRIPTION
This branch allows sqlite attached databases to be remote URIs. Tests complete for both Millstone and TileMill.
