### PR TITLE
Support localizing Carto URIs

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -303,7 +303,7 @@ function resolve(options, callback) {
         resolved.Stylesheet.forEach(function(s, index) {
 
             // Get all unique URIs in stylesheet
-            var URIs = _.uniq(s.data.match(/url\((.*)\)/g));
+            var URIs = _.uniq(s.data.match(/url\((.*)\)/g) || []);
 
             // Update number of async calls so that we don't
             // call this() too soon (before everything is done)


### PR DESCRIPTION
All URIs in the Carto stylesheet(s) are now localized, so you can do:
`point-file: url('http://a.tiles.mapbox.com/v3/marker/pin-l-campsite+000000.png');`

It does not symlink the cached files to the project dir. Should it? Should it also symlink absolute paths like it does with datasources?

Relevant ticket in TileMill: mapbox/tilemill#1498
