### PR TITLE
carto css URI localization fix

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -290,6 +290,7 @@ function resolve(options, callback) {
                         data: data.toString()
                     };
                     next(err);
+                    localizeCartoURIs(resolved.Stylesheet[index]);
                 });
             }
 
@@ -305,11 +306,12 @@ function resolve(options, callback) {
                     data: data
                 };
                 next(err);
+                localizeCartoURIs(resolved.Stylesheet[index]);
             });
         });
 
         // Handle URIs within the Carto CSS
-        resolved.Stylesheet.forEach(function(s, index) {
+        function localizeCartoURIs(s) {
 
             // Get all unique URIs in stylesheet
             var URIs = _.uniq(s.data.match(/url\((.*)\)/g) || []);
@@ -330,10 +332,10 @@ function resolve(options, callback) {
                         next(err);
                     });
                 } else {
-                    next();
+                    next(err);
                 }
             });
-        });
+        }
 
         resolved.Layer.forEach(function(l, index) {
             if (!l.Datasource || !l.Datasource.file) return next();


### PR DESCRIPTION
Avoid trying to localize URIs within carto css before the stylesheet itself has been localized.
