### PR TITLE
Use request (better proxy support)

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -44,30 +44,28 @@ function download(url, filepath, callback) {
         downloads[url] = new EventEmitter();
         pool.acquire(function(obj) {
             pool.release(obj);
-            var writeStream = fs.createWriteStream(dl);
-            request({
+            var req = request({
                 url: url,
                 proxy: process.env.HTTP_PROXY
-            }, requestDone).pipe(writeStream);
-            function requestDone (err, response, body) {
-                if (err) {
-                    downloads[url].emit('done', err);
-                    delete downloads[url];
-                    return callback(err);
-                }
+            });
+            req.pipe(fs.createWriteStream(dl)).on('error', function(err) {
+                downloads[url].emit('done', err);
+                delete downloads[url];
+                return callback(err);
+            }).on('close', function() {
                 fs.rename(dl, filepath, function(err) {
                     // We store the headers from the download in a hidden file
                     // alongside the data for future reference. Currently, we
                     // only use the `content-disposition` header to determine
                     // what kind of file we downloaded if it doesn't have an
                     // extension.
-                    fs.writeFile(metapath(filepath), JSON.stringify(response.headers), 'utf-8', function(err) {
+                    fs.writeFile(metapath(filepath), JSON.stringify(req.req.res.headers), 'utf-8', function(err) {
                         downloads[url].emit('done', err, filepath);
                         delete downloads[url];
                         return callback(err, filepath);
                     });
                 });
-            }
+            });
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "underscore": "~1.3.3",
         "step": "~0.0.5",
         "generic-pool": "1.0.x",
-        "get": "~1.1.10",
+        "request": "~2.11.0",
         "srs": "~0.2.15",
         "zipfile": "0.x",
         "sqlite3": "2.x",


### PR DESCRIPTION
Switches to using [request](https://github.com/mikeal/request/), which has better proxy support. Proxied requests for HTTPS resources should now work.

@springmeyer 
