### PR TITLE
Replace remote carto uris with localized paths, fixing #56

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -399,6 +399,7 @@ function resolve(options, callback) {
                 if (uri.protocol && (uri.protocol == 'http:' || uri.protocol == 'https:')) {
                     var filepath = path.join(cache, cachepath(matched[2]));
                     localize(uri.href, {filepath:filepath,name:s.id}, function(err, file) {
+                        s.data = s.data.replace(matched[0], 'url(' + file + ')');
                         next(err);
                     });
                 } else {


### PR DESCRIPTION
Without this patch resources in carto URI are not replaced with their localized pathnames. See #56
