### PR TITLE
Fix CartoURI replacement when URL contains RegExp special chars

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -416,8 +416,7 @@ function resolve(options, callback) {
                 if (uri.protocol && (uri.protocol == 'http:' || uri.protocol == 'https:')) {
                     var filepath = path.join(cache, cachepath(u));
                     localize(uri.href, {filepath:filepath,name:s.id}, function(err, file) {
-                        var expr_all = new RegExp(u,'gm');
-                        s.data = s.data.replace(expr_all, file);
+                        s.data = s.data.split(u).join(file);
                         next(err);
                     });
                 } else {


### PR DESCRIPTION
Fixes issues #72 and #69
Lacks a testcase as I didn't understood how they are organized.
