### PR TITLE
More careful file ext vs header ext decision

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -699,7 +699,12 @@ function resolve(options, callback) {
 
                 var name = l.name || 'layer-' + index;
 
-                var ext = ext || path.extname(d.file);
+                // Check whether extension is recognized
+                function idealExt(ext) {
+                    var exts = ['.csv', '.tsv', '.txt', '.osm', '.gpx', '.geojson', '.json', '.kml', '.rss'];
+                    if (_.include(exts, ext)) return ext;
+                }
+                var ext = idealExt(ext) || idealExt(path.extname(d.file)) || ext || path.extname(d.file);
                 d.type = d.type || valid_ds_extensions[ext];
                 switch (ext) {
                 case '.csv':


### PR DESCRIPTION
Millstone was using the extension detected from header even if it wasn't valid and the filename extension was valid. See mapbox/tilemill#1729

This updates the preference order to:
1. recognized extension from header
2. recognized extension from filename
3. extension from header
4. extension from filename
