### PR TITLE
Always honour filepath option in .download. Closes #105.

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -104,8 +104,9 @@ function download(url, options, callback) {
     var dl = options.filepath + '.download';
     // If this file is already being downloaded, attach the callback
     // to the existing EventEmitter
-    if (downloads[url]) {
-        return downloads[url].once('done', callback);
+    var dkey = options.filepath + '|' + url;
+    if (downloads[dkey]) {
+        return downloads[dkey].once('done', callback);
     } else {
         pool.acquire(function(err, obj) {
             var make_message = function() {
@@ -115,13 +116,13 @@ function download(url, options, callback) {
                 return msg;
             };
             var return_on_error = function(err) {
-                downloads[url].emit('done', err);
-                delete downloads[url];
+                downloads[dkey].emit('done', err);
+                delete downloads[dkey];
                 err.message =  make_message() + " ("+err.message+")";
                 pool.release(obj);
                 return callback(err);
             }
-            downloads[url] = new EventEmitter();
+            downloads[dkey] = new EventEmitter();
             if (err) {
                 return return_on_error(err);
             } else {
@@ -148,8 +149,8 @@ function download(url, options, callback) {
                         pool.release(obj);
                         fs.rename(dl, options.filepath, function(err) {
                             if (err) {
-                              downloads[url].emit('done', err);
-                              delete downloads[url];
+                              downloads[dkey].emit('done', err);
+                              delete downloads[dkey];
                               return callback(err);
                             } else {
                                 if (env == 'development') console.error("[millstone] finished downloading '" + options.filepath + "'");
@@ -163,8 +164,8 @@ function download(url, options, callback) {
                                     req_meta.path = req.req.res.request.path;
                                 }
                                 fs.writeFile(metapath(options.filepath), JSON.stringify(req_meta), 'utf-8', function(err) {
-                                    downloads[url].emit('done', err, options.filepath);
-                                    delete downloads[url];
+                                    downloads[dkey].emit('done', err, options.filepath);
+                                    delete downloads[dkey];
                                     return callback(err, options.filepath);
                                 });
                             }


### PR DESCRIPTION
With this patch the same URL file may be downloaded multiple times IFF the download requests use different local filepaths. 
