### PR TITLE
Fix metafile idempotence

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -237,7 +237,9 @@ function metapath(filepath) {
     return path.join(path.dirname(filepath), '.' + path.basename(filepath));
 }
 
-    if (exists(metafile)) {
+function add_item_to_metafile(metafile,key,item,callback) {
+	exists(metafile, function(exists) {
+    if (exists) {
         fs.readFile(metafile, 'utf-8', function(err, data) {
             if (err) return callback(err);
             var meta;
@@ -246,7 +248,7 @@ function metapath(filepath) {
             } catch (err) {
                 return callback(err);
             }
-            meta['unzipped_file'] = item;
+            meta[key] = item;
             fs.writeFile(metafile, JSON.stringify(meta), 'utf-8', function(err) {
                 if (err) return callback(err);
                 return callback(null);
@@ -254,12 +256,13 @@ function metapath(filepath) {
         });
     } else {
         var data = {};
-        data['unzipped_file'] = item;
+        data[key] = item;
         fs.writeFile(metafile, JSON.stringify(data), 'utf-8', function(err) {
             if (err) return callback(err);
             return callback(null);
         });
     }
+	});
 }
 
 function isRelative(loc) {


### PR DESCRIPTION
add_item_to_metafile() was using fs/path.exists() incorrectly, resulting in a short circuit to the function's second condition (else). Therefore, the metafile could only contain a single key-value and could not be updated using the add_item_to_metafile() function. exists() now calls a callback rather than expecting a boolean value. add_item_to_metafile() now also accepts a key rather than it being hard-coded as 'unzipped_file' so the function may be used elsewhere.

This branch passes all tests.

Thanks!
