### PR TITLE
Add Node.js 0.12.x to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
  - "0.10"
+ - "0.11"
  - "0.12"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
  - "0.10"
- - "0.11"
+ - "0.12"
 
 install:
  - npm install --fallback-to-build=false


### PR DESCRIPTION
Travis builds should pass in Node.js 0.12.x once https://github.com/mapbox/millstone/pull/119 is accepted.