### PR TITLE
Use console.info for non-error messages in development

### DIFF
--- a/lib/millstone.js
+++ b/lib/millstone.js
@@ -100,7 +100,7 @@ function download(url, options, callback) {
                         msg += 's';
                     }
                     msg += ': ' + _(in_use).map(function(f) { return path.basename(f); });
-                    console.error(msg);
+                    console.info(msg);
                 }
                 download_last_count = in_use.length;
             },5000);
@@ -136,7 +136,7 @@ function download(url, options, callback) {
             if (err) {
                 return return_on_error(err);
             } else {
-                if (env == 'development') console.error("[millstone] downloading: '" + url + "'");
+                if (env == 'development') console.info("[millstone] downloading: '" + url + "'");
                 var req;
                 try {
                 req = request({
@@ -163,7 +163,7 @@ function download(url, options, callback) {
                               delete downloads[dkey];
                               return callback(err);
                             } else {
-                                if (env == 'development') console.error("[millstone] finished downloading '" + options.filepath + "'");
+                                if (env == 'development') console.info("[millstone] finished downloading '" + options.filepath + "'");
                                 // We store the headers from the download in a hidden file
                                 // alongside the data for future reference. Currently, we
                                 // only use the `content-disposition` header to determine
@@ -334,7 +334,7 @@ function readExtension(file, cb) {
         try {
             var ext = guessExtension(JSON.parse(data));
             if (ext) {
-                if (env == 'development') console.error("[millstone] detected extension of '" + ext + "' for '" + file + "'");
+                if (env == 'development') console.info("[millstone] detected extension of '" + ext + "' for '" + file + "'");
             }
             return cb(null, ext);
         } catch (e) {
@@ -355,11 +355,11 @@ function unzip(file, callback) {
             var meta = JSON.parse(meta_data);
             var dest_file = meta['unzipped_file'];
             if (dest_file && existsSync(dest_file)) {
-                if (env == 'development') console.error('[millstone] found previously unzipped file: ' + dest_file);
+                if (env == 'development') console.info('[millstone] found previously unzipped file: ' + dest_file);
                 return callback(null,dest_file);
             }
         } else {
-            if (env == 'development') console.error('[millstone] empty meta file for zipfile: ' + metafile);
+            if (env == 'development') console.info('[millstone] empty meta file for zipfile: ' + metafile);
         }
     }
     catch (err) {
@@ -607,7 +607,7 @@ function resolve(options, callback) {
 
         resolved.Stylesheet.forEach(function(s, index) {
             if (typeof s !== 'string') {
-                if (env == 'development') console.error("[millstone] processing style '" + s.id + "'");
+                if (env == 'development') console.info("[millstone] processing style '" + s.id + "'");
                 return localizeCartoURIs(s,next);
             }
             var uri = url.parse(s);
@@ -658,7 +658,7 @@ function resolve(options, callback) {
         if (!remaining) return this();
         resolved.Layer.forEach(function(l, index) {
             if (!l.Datasource || !l.Datasource.file) return next();
-            if (env == 'development') console.error("[millstone] processing layer '" + l.name + "'");
+            if (env == 'development') console.info("[millstone] processing layer '" + l.name + "'");
 
             // TODO find  better home for this check.
             if (l.Datasource.ttl) checkTTL(cache, l);
@@ -983,7 +983,7 @@ function resolve(options, callback) {
         resolved.srs = resolved.srs || SRS['900913'];
         fixSRS(resolved);
         resolved.Layer.forEach(fixSRS);
-        if (!err && env == 'development') console.error("[millstone] finished processing '" + options.base + "'");
+        if (!err && env == 'development') console.info("[millstone] finished processing '" + options.base + "'");
         if (Object.keys(downloads).length < 1) {
             clearInterval(download_log_interval);
             download_log_interval = null;


### PR DESCRIPTION
Although console.error calls are only used in development environment it would be better to differentiate between error and information messages when outputting them.